### PR TITLE
Change Dialog References + Fixes around login function

### DIFF
--- a/lib/login/login.dart
+++ b/lib/login/login.dart
@@ -16,7 +16,12 @@ class Login extends StatelessWidget {
           child: Consumer(builder: (context, ref, _) {
             final _emailProvider = ref.watch(emailProvider.notifier);
             final _passwordProvider = ref.watch(passwordProvider.notifier);
-            final _loginInstance = ref.read(insProvider);
+
+            // stateのスタックを破棄(絶対もっといい方法がある。。)
+            if (_emailProvider.state != '') {
+              _emailProvider.state = '';
+              _passwordProvider.state = '';
+            }
 
             return Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -42,22 +47,24 @@ class Login extends StatelessWidget {
                   width: double.infinity,
                   // ログインボタン
                   child: ElevatedButton(
-                    child: Text('ログイン'),
+                    child: const Text('ログイン'),
                     onPressed: () async {
                       try {
                         // メール/パスワードでログイン
-                        await _loginInstance.login(
+                        await login(
                             _emailProvider.state, _passwordProvider.state);
                         // ログインに成功した場合
+                        // pushReplacement：画面置き換えして全画面へ遷移できなくする
+                        // →いまいち挙動がわかってない、、
                         await Navigator.of(context).pushReplacement(
                           MaterialPageRoute(builder: (context) {
-                            return Home();
+                            return const Home();
                           }),
                         );
                       } catch (e) {
                         // ログインに失敗した場合
                         String msg = "ログインに失敗しました：${e.toString()}";
-                        await _loginInstance.dialog(context, msg, _);
+                        await dialog(context, msg, _);
                       }
                     },
                   ),
@@ -66,13 +73,8 @@ class Login extends StatelessWidget {
                   child: TextButton(
                     child: const Text('新規登録'),
                     onPressed: () {
-                      Navigator.push(context,
+                      Navigator.of(context).push(
                           MaterialPageRoute(builder: (context) => const New()));
-                      // Navigator.of(context).pushReplacement(
-                      //   MaterialPageRoute(builder: (context) {
-                      //     return const New();
-                      //   }),
-                      // );
                     },
                   ),
                 ),

--- a/lib/login/login_model.dart
+++ b/lib/login/login_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final emailProvider =
@@ -16,37 +15,42 @@ class LoginNotifier extends StateNotifier<String> {
   String setStr(String filedText) {
     return state = filedText;
   }
+}
 
-  // User新規登録
-  Future register(String email, String password) async {
-    final FirebaseAuth auth = FirebaseAuth.instance;
-    await auth.createUserWithEmailAndPassword(
-      email: email,
-      password: password,
-    );
-  }
+// User新規登録
+Future register(String email, String password) async {
+  final FirebaseAuth auth = FirebaseAuth.instance;
+  await auth.createUserWithEmailAndPassword(
+    email: email,
+    password: password,
+  );
+}
 
-  // ログイン
-  Future login(String email, String password) async {
-    final FirebaseAuth auth = FirebaseAuth.instance;
-    await auth.signInWithEmailAndPassword(
-      email: email,
-      password: password,
-    );
-  }
+// ログイン
+Future login(String email, String password) async {
+  final FirebaseAuth auth = FirebaseAuth.instance;
+  await auth.signInWithEmailAndPassword(
+    email: email,
+    password: password,
+  );
+}
 
-  // ダイアログ
-  Future dialog(context, message, page) {
-    return showDialog(
-      context: context,
-      builder: (_) {
-        return AlertDialog(
+// ダイアログ
+Future dialog(context, message, page) {
+  return showDialog(
+    barrierDismissible: false,
+    context: context,
+    builder: (BuildContext context) {
+      return WillPopScope(
+        // 戻るボタンを無効にする
+        onWillPop: () async => false,
+        child: AlertDialog(
           title: Text(message),
           actions: <Widget>[
             // 登録成功時 => 画面遷移
             if (page != null)
               TextButton(
-                child: Text("ok"),
+                child: const Text("ok"),
                 onPressed: () => Navigator.of(context)
                     .pushReplacement(MaterialPageRoute(builder: (context) {
                   return page;
@@ -56,12 +60,13 @@ class LoginNotifier extends StateNotifier<String> {
             // 登録失敗時 => 入力画面に戻る
             if (page == null)
               TextButton(
-                child: Text("ok"),
-                onPressed: () => Navigator.pop(context),
+                child: const Text("ok"),
+                onPressed: () =>
+                    Navigator.of(context, rootNavigator: true).pop(),
               ),
           ],
-        );
-      },
-    );
-  }
+        ),
+      );
+    },
+  );
 }

--- a/lib/login/new.dart
+++ b/lib/login/new.dart
@@ -31,7 +31,6 @@ class NewBody extends StatelessWidget {
           child: Consumer(builder: (context, ref, _) {
             final _emailProvider = ref.watch(emailProvider.notifier);
             final _passwordProvider = ref.watch(passwordProvider.notifier);
-            final _loginInstance = ref.read(insProvider);
 
             return Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -61,15 +60,15 @@ class NewBody extends StatelessWidget {
                     onPressed: () async {
                       try {
                         // メール/パスワードでユーザー登録
-                        await _loginInstance.register(
+                        await register(
                             _emailProvider.state, _passwordProvider.state);
                         // ユーザー登録に成功した場合
-                        await _loginInstance.dialog(context, successMessage,
+                        await dialog(context, successMessage,
                             const Setup(newJudge: true));
                       } catch (e) {
                         // ユーザー登録に失敗した場合
                         String msg = "$mistakeMessage：${e.toString()}";
-                        await _loginInstance.dialog(context, msg, _);
+                        await dialog(context, msg, _);
                       }
                     },
                   ),

--- a/lib/target/target.dart
+++ b/lib/target/target.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:habitual_records/home/home.dart';
 import 'package:habitual_records/target/target_model.dart';
+import '../login/login_model.dart';
 
 class Target extends StatelessWidget {
   const Target({Key? key}) : super(key: key);
@@ -56,7 +57,7 @@ class TargetBody extends StatelessWidget {
                       // 登録に成功した場合
                       if (resultMsg == successMessage) {
                         _targetProvider.resetStr();
-                        await dialog(context, resultMsg, Home());
+                        await dialog(context, resultMsg, const Home());
                       } else {
                         // 登録に失敗した場合
                         await dialog(context, resultMsg, _);

--- a/lib/target/target_model.dart
+++ b/lib/target/target_model.dart
@@ -122,33 +122,3 @@ class DropDown extends StatelessWidget {
     );
   }
 }
-
-// ダイアログ
-Future dialog(context, message, page) {
-  return showDialog(
-    context: context,
-    builder: (_) {
-      return AlertDialog(
-        title: Text(message),
-        actions: <Widget>[
-          // 登録成功時 => 画面遷移
-          if (page != null)
-            TextButton(
-              child: const Text("ok"),
-              onPressed: () => Navigator.of(context)
-                  .pushReplacement(MaterialPageRoute(builder: (context) {
-                return page;
-              })),
-            ),
-
-          // 登録失敗時 => 入力画面に戻る
-          if (page == null)
-            TextButton(
-              child: const Text("ok"),
-              onPressed: () => Navigator.pop(context),
-            ),
-        ],
-      );
-    },
-  );
-}


### PR DESCRIPTION
close #6 

- ログイン後、ログアウトしてもtextFiledの値が保持されたままなので、textFiledに値入れなくてもそのままログインできてしまう。
→StateNotifierProviderの'state'を初期化する処理を追加。

- ログイン後、ログアウトして、再ログインに失敗するとブラックアウトする。
→Navigeter.popの指定が原因のはず？（挙動はいまいちわかっていない。）

- 各ページのDialogのボタン以外反応しないように修正