### PR TITLE
Firestoreの環境分け

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,7 @@ app.*.map.json
 /android/app/release
 
 !*.gitignore
-/android/app/google-services.json
-/ios/Runner/GoogleService-Info.plist
+/android/app/src/debug/google-services.json
+/android/app/src/release/google-services.json
+/ios/Runner/GoogleService-Info-dev.plist
+/ios/Runner/GoogleService-Info-release.plist

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -12,4 +12,5 @@ key.properties
 **/*.keystore
 **/*.jks
 
-/app/google-services.json
+/app/src/debug/google-services.json
+/app/src/release/google-services.json

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -33,4 +33,5 @@ Runner/GeneratedPluginRegistrant.*
 !default.pbxuser
 !default.perspectivev3
 
-/Runner/GoogleService-Info.plist
+/Runner/GoogleService-Info-dev.plist
+/Runner/GoogleService-Info-release.plist

--- a/ios/Runner/GoogleService-Info-dev.plist
+++ b/ios/Runner/GoogleService-Info-dev.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>342577820989-f58jo3tf5c8d6vkshi30hdbpcbell60i.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.342577820989-f58jo3tf5c8d6vkshi30hdbpcbell60i</string>
+	<key>API_KEY</key>
+	<string>AIzaSyCShEfvGVU5kxertJh0MtoMWU1IH7v_sZQ</string>
+	<key>GCM_SENDER_ID</key>
+	<string>342577820989</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.Yuto.habitual-records</string>
+	<key>PROJECT_ID</key>
+	<string>habitual-records-dev</string>
+	<key>STORAGE_BUCKET</key>
+	<string>habitual-records-dev.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:342577820989:ios:02d2ba04d7414dacfb4154</string>
+</dict>
+</plist>

--- a/lib/common/is_release.dart
+++ b/lib/common/is_release.dart
@@ -1,0 +1,10 @@
+// 本番かリリースかを判断する
+// releaseモードならtrueを返す
+bool isRelease() {
+  bool isRelease;
+  // release環境ならtrue
+  const bool.fromEnvironment('dart.vm.product')
+      ? isRelease = true
+      : isRelease = false;
+  return isRelease;
+}

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../common/dropdown.dart';
+import '../../common/is_release.dart';
 import '../../const/const.dart';
 import '../record/record.dart';
 import '../setup/setup.dart';
@@ -42,7 +43,7 @@ class Home extends ConsumerWidget {
 
           return Scaffold(
             appBar: AppBar(
-              title: const Text('習慣化記録'),
+              title: Text(isRelease() ? '習慣化記録' : '習慣化記録(開発環境)'),
               leading: IconButton(
                 icon: const Icon(Icons.settings),
                 iconSize: 20,

--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../common/is_release.dart';
 import '../home/home.dart';
 import 'login_model.dart';
 import 'new.dart';
@@ -29,7 +30,9 @@ class Login extends StatelessWidget {
                 children: <Widget>[
                   // メールアドレス入力
                   TextFormField(
-                    decoration: const InputDecoration(labelText: 'メールアドレス'),
+                    decoration: InputDecoration(
+                      labelText: isRelease() ? 'メールアドレス' : 'メールアドレス(開発環境)',
+                    ),
                     onChanged: emailStateProvider.setStr,
                   ),
 

--- a/lib/pages/login/new.dart
+++ b/lib/pages/login/new.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../common/dialog.dart';
+import '../../common/is_release.dart';
 import '../setup/setup.dart';
 import 'login_model.dart';
 
@@ -42,7 +43,9 @@ class NewBody extends StatelessWidget {
                 children: <Widget>[
                   // メールアドレス入力
                   TextFormField(
-                    decoration: const InputDecoration(labelText: 'メールアドレス'),
+                    decoration: InputDecoration(
+                      labelText: isRelease() ? 'メールアドレス' : 'メールアドレス(開発環境)',
+                    ),
                     onChanged: emailStateProvider.setStr,
                   ),
 

--- a/lib/pages/record/record.dart
+++ b/lib/pages/record/record.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../common/is_release.dart';
 import 'record_model.dart';
 
 class Record extends StatelessWidget {
@@ -9,7 +10,7 @@ class Record extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(text),
+        title: Text(text + (isRelease() ? '' : '(開発環境)')),
         // 引数のtextの値でIconButton表示/非表示を判定
         actions: (() {
           if (text == '月毎の記録') {

--- a/lib/pages/target/target.dart
+++ b/lib/pages/target/target.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:habitual_records/pages/target/target_model.dart';
 import '../../common/dialog.dart';
 import '../../common/dropdown.dart';
+import '../../common/is_release.dart';
 import '../../const/const.dart';
 import '../home/home.dart';
 
@@ -13,7 +14,7 @@ class Target extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('目標の設定'),
+        title: Text(isRelease() ? '目標の設定' : '目標の設定(開発環境)'),
       ),
       body: const TargetBody(),
     );


### PR DESCRIPTION
close #34

# 対応したこと
- Firestoreの本番環境と開発環境を切り分けるように設定
- 環境によって表示する内容を切り替え(開発環境と分かるように)